### PR TITLE
Greedy regex

### DIFF
--- a/Sources/MimeParser/RFC822ParsingUtilities.swift
+++ b/Sources/MimeParser/RFC822ParsingUtilities.swift
@@ -37,7 +37,7 @@ struct RFC822HeaderFieldsPartitioner {
     }
     
     func fields(in string: String) throws -> [RFC822HeaderField] {
-        let regex = try! NSRegularExpression(pattern: "(.+):\\s*(.+)", options: [])
+        let regex = try! NSRegularExpression(pattern: "(.+?):\\s*(.+)", options: [])
         let results = regex.matches(in: string, options: [], range: string.nsRange)
         
         return try results.map { result in

--- a/Tests/MimeParserTests/RFC822ParsingUtilitiesTests.swift
+++ b/Tests/MimeParserTests/RFC822ParsingUtilitiesTests.swift
@@ -69,13 +69,14 @@ class RFC822ParsingUtilitiesTests: XCTestCase {
         let str = """
             a: b
             c:  d
+            e: f:g:h
             """
         
         // When
         let fields = try partitioner.fields(in: str)
         
         // Then
-        let expected = [RFC822HeaderField(name: "a", body: "b"), RFC822HeaderField(name: "c", body: "d")]
+        let expected = [RFC822HeaderField(name: "a", body: "b"), RFC822HeaderField(name: "c", body: "d"), RFC822HeaderField(name: "e", body: "f:g:h")]
         XCTAssertEqual(fields, expected)
     }
     


### PR DESCRIPTION
There was an issue with parsing header fields such as the send date for emails.

When parsing headers, the 1st colon that the regex is looking for was doing a "greedy" match which was incorrect.  For example a header of `Date: Tue, 2 Jun 2009 14:47:21 -0400`  would match such that the header name would be`Date: Tue, 2 Jun 2009 14:47` and the body would be `21 -0400`.

This fixes it so that the match is non-greedy which is the desired behavior.   The appropriate unit test was altered to test this aspect as well.