### PR TITLE
Case-insensitive header parsing

### DIFF
--- a/Sources/MimeParser/HeaderParser.swift
+++ b/Sources/MimeParser/HeaderParser.swift
@@ -68,7 +68,7 @@ struct HeaderParser {
         }
         
         let contentTransferEncoding: ContentTransferEncoding?
-        if let field = fieldsByName["Content-Transfer-Encoding"] {
+        if let field = fieldsByName[caseInsensitive: "Content-Transfer-Encoding"] {
             let parser = ContentTransferEncodingFieldParser()
             contentTransferEncoding = try parser.parse(field.body)
             fields.remove(field)
@@ -77,7 +77,7 @@ struct HeaderParser {
         }
         
         let contentType: ContentType?
-        if let field = fieldsByName["Content-Type"] {
+        if let field = fieldsByName[caseInsensitive: "Content-Type"] {
             let parser = ContentTypeParser()
             contentType = try parser.parse(field.body)
             fields.remove(field)
@@ -86,7 +86,7 @@ struct HeaderParser {
         }
         
         let contentDisposition: ContentDisposition?
-        if let field = fieldsByName["Content-Disposition"] {
+        if let field = fieldsByName[caseInsensitive: "Content-Disposition"] {
             let parser = ContentDispositionFieldParser()
             contentDisposition = try parser.parse(field.body)
             fields.remove(field)

--- a/Sources/MimeParser/Utilities.swift
+++ b/Sources/MimeParser/Utilities.swift
@@ -138,3 +138,21 @@ extension String {
     }
     
 }
+
+extension Dictionary where Key == String {
+    subscript(caseInsensitive key: Key) -> Value? {
+        get {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                return self[k]
+            }
+            return nil
+        }
+        set {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                self[k] = newValue
+            } else {
+                self[key] = newValue
+            }
+        }
+    }
+}

--- a/Tests/MimeParserTests/UtilitiesTests.swift
+++ b/Tests/MimeParserTests/UtilitiesTests.swift
@@ -116,4 +116,20 @@ class UtilitiesTests: XCTestCase {
             XCTFail("Invalid range")
         }
     }
+
+    func testCaseInsensitiveDictionary() {
+        var dictionary: [String: Int] = ["One":1, "Two":2, "Three":3]
+
+        XCTAssertEqual(1, dictionary[caseInsensitive: "ONE"])
+        XCTAssertEqual(2, dictionary[caseInsensitive: "Two"])
+        XCTAssertEqual(3, dictionary[caseInsensitive: "three"])
+
+        dictionary[caseInsensitive: "one"] = 11
+        dictionary[caseInsensitive: "TWO"] = 22
+        dictionary[caseInsensitive: "ThReE"] = 33
+
+        XCTAssertEqual(11, dictionary["One"])
+        XCTAssertEqual(22, dictionary["Two"])
+        XCTAssertEqual(33, dictionary["Three"])
+    }
 }

--- a/Tests/Supporting Files/SimpleMessage.txt
+++ b/Tests/Supporting Files/SimpleMessage.txt
@@ -8,7 +8,7 @@ Message-Id: <44D3325-20F-41D2-B8E7-F7D37E7F98D3@fnord.com>
 Date: Thu, 10 Dec 2017 22:34:26 +0100
 To: Fnord 2 <fnord2@fnord.com>
 Content-Transfer-Encoding: 7bit
-Content-Type: text/plain;
+Content-type: text/plain;
 	charset=us-ascii
 Mime-Version: 1.0 (Mac OS X Mail 11.1 \(3445.4.7\))
 X-Mailer: Apple Mail (2.3445.4.7)

--- a/Tests/Supporting Files/SimpleMessageWithBinaryAttachment.txt
+++ b/Tests/Supporting Files/SimpleMessageWithBinaryAttachment.txt
@@ -28,7 +28,7 @@ Content-Disposition: attachment;
 Content-Type: application/octet-stream;
 	x-unix-mode=0644;
 	name="binary.data"
-Content-Transfer-Encoding: base64
+Content-transfer-encoding: base64
 
 //////////8=
 --Apple-Mail=_B06AEA86-0328-4832-8B68-6E5C64B48A84--

--- a/Tests/Supporting Files/SimpleMessageWithTextAttachment.txt
+++ b/Tests/Supporting Files/SimpleMessageWithTextAttachment.txt
@@ -28,7 +28,7 @@ Content-Transfer-Encoding: 7bit
 Content-Type: text/plain;
 	x-unix-mode=0644;
 	name="MyAttachment.txt"
-Content-Disposition: attachment;
+content-disposition: attachment;
 	filename=MyAttachment.txt
 
 fnord


### PR DESCRIPTION
This addresses issue #1 logged in the repo which we ran into as well.

When looking for specific headers (such as "Content-type" the parser now does a case-insensitive search for them as the RFCs allow for these to vary in case.  Tests also include varying cases to ensure the code allows for it.