### PR TITLE
Parse body parts with 0 length

### DIFF
--- a/MimeParser.xcodeproj/project.pbxproj
+++ b/MimeParser.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		088827DD1FDEBE6E00FEE3BA /* MimeParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 088827BE1FDEB12500FEE3BA /* MimeParser.framework */; };
 		08ABE7762063D04A00F945CF /* SpecialCharsBoundary.txt in Resources */ = {isa = PBXBuildFile; fileRef = 08ABE7752063D04A00F945CF /* SpecialCharsBoundary.txt */; };
 		08ABE7772063D04A00F945CF /* SpecialCharsBoundary.txt in Resources */ = {isa = PBXBuildFile; fileRef = 08ABE7752063D04A00F945CF /* SpecialCharsBoundary.txt */; };
+		0C9F212121EE6394009DCA21 /* MeetingRequestWithZeroLengthPart.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C9F211F21EE61D6009DCA21 /* MeetingRequestWithZeroLengthPart.txt */; };
+		0C9F212221EE6395009DCA21 /* MeetingRequestWithZeroLengthPart.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0C9F211F21EE61D6009DCA21 /* MeetingRequestWithZeroLengthPart.txt */; };
 		4472876B20CF23A500CD7412 /* EmailWithApplicationAttachment.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4472876A20CF23A500CD7412 /* EmailWithApplicationAttachment.txt */; };
 		4472876C20CF23A500CD7412 /* EmailWithApplicationAttachment.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4472876A20CF23A500CD7412 /* EmailWithApplicationAttachment.txt */; };
 		813C0B4920D18A11007CF9B5 /* EmailParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813C0B4820D18A11007CF9B5 /* EmailParsingTests.swift */; };
@@ -74,6 +76,7 @@
 		088827BE1FDEB12500FEE3BA /* MimeParser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MimeParser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		088827D81FDEBE6E00FEE3BA /* MimeParserTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MimeParserTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		08ABE7752063D04A00F945CF /* SpecialCharsBoundary.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SpecialCharsBoundary.txt; sourceTree = "<group>"; };
+		0C9F211F21EE61D6009DCA21 /* MeetingRequestWithZeroLengthPart.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MeetingRequestWithZeroLengthPart.txt; sourceTree = "<group>"; };
 		4472876A20CF23A500CD7412 /* EmailWithApplicationAttachment.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EmailWithApplicationAttachment.txt; sourceTree = "<group>"; };
 		813C0B4820D18A11007CF9B5 /* EmailParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailParsingTests.swift; sourceTree = "<group>"; };
 		8145B1C620D187440019E405 /* MimeParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MimeParsingTests.swift; sourceTree = "<group>"; };
@@ -215,6 +218,7 @@
 			children = (
 				4472876A20CF23A500CD7412 /* EmailWithApplicationAttachment.txt */,
 				81E3FCAC1FDF1EB600C00F25 /* Info.plist */,
+				0C9F211F21EE61D6009DCA21 /* MeetingRequestWithZeroLengthPart.txt */,
 				81E3FCB21FDF1EB600C00F25 /* MessageWithEnclosedMessageAsAttachment.txt */,
 				81E3FCB11FDF1EB600C00F25 /* QuotedPrintableMessage.txt */,
 				81E3FCAD1FDF1EB600C00F25 /* SimpleMessage.txt */,
@@ -386,6 +390,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08ABE7772063D04A00F945CF /* SpecialCharsBoundary.txt in Resources */,
+				0C9F212221EE6395009DCA21 /* MeetingRequestWithZeroLengthPart.txt in Resources */,
 				81E3FCBC1FDF1EBC00C00F25 /* SimpleMessageWithBinaryAttachment.txt in Resources */,
 				81E3FCBA1FDF1EBC00C00F25 /* QuotedPrintableMessage.txt in Resources */,
 				81E3FCBD1FDF1EBC00C00F25 /* SimpleMessageWithBinaryAttachmentCRLN.txt in Resources */,
@@ -408,6 +413,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08ABE7762063D04A00F945CF /* SpecialCharsBoundary.txt in Resources */,
+				0C9F212121EE6394009DCA21 /* MeetingRequestWithZeroLengthPart.txt in Resources */,
 				81E3FCB61FDF1EBB00C00F25 /* SimpleMessageWithBinaryAttachment.txt in Resources */,
 				81E3FCB41FDF1EBB00C00F25 /* QuotedPrintableMessage.txt in Resources */,
 				81E3FCB71FDF1EBB00C00F25 /* SimpleMessageWithBinaryAttachmentCRLN.txt in Resources */,

--- a/Sources/MimeParser/MimeParser.swift
+++ b/Sources/MimeParser/MimeParser.swift
@@ -24,7 +24,7 @@ struct MimePartsSplitter {
                 break
             }
             
-            if searchRange.lowerBound == nextEmptyLineRange.lowerBound {
+            if searchRange.lowerBound == nextEmptyLineRange.lowerBound || nextEmptyLineRange.upperBound == string.endIndex {
                 emptyLineRange = nextEmptyLineRange
             } else {
                 searchRange = Range<String.Index>(uncheckedBounds: (nextEmptyLineRange.upperBound, string.endIndex))

--- a/Tests/Supporting Files/MeetingRequestWithZeroLengthPart.txt
+++ b/Tests/Supporting Files/MeetingRequestWithZeroLengthPart.txt
@@ -1,0 +1,30 @@
+From: John Doe <jdoe@fnord.com>
+To: F Nnord <fnord@fnord.com>
+Received: from MWHPR16MB1535.namprd16.prod.outlook.com
+ (2603:10b6:301:75::36) by BYAPR16MB2439.namprd16.prod.outlook.com with
+ HTTPS via MWHPR0201CA0095.NAMPRD02.PROD.OUTLOOK.COM; Tue, 18 Sep 2018
+ 18:07:03 +0000
+Content-Transfer-Encoding: binary
+Subject: Meeting request
+Thread-Topic: Meeting request
+Thread-Index: AdRPemY2vb6lpePsIk+sXErWYWzZnw==
+Date: Tue, 18 Sep 2018 18:07:02 +0000
+Message-Id:
+ <MWHPR16MB150401D305C7FEBD3C5400B8BF1D0@MWHPR16MB1504.namprd16.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+MIME-Version: 1.0
+Return-Path: jdoe@fnord.com
+Content-Type: multipart/mixed;
+ boundary="----sinikael-?=_1-15475657792290.9819128808191682"
+
+------sinikael-?=_1-15475657792290.9819128808191682
+Content-Type: multipart/related;
+ boundary="----sinikael-?=_2-15475657792290.9819128808191682"
+
+------sinikael-?=_2-15475657792290.9819128808191682
+Content-Type: text/plain
+
+------sinikael-?=_2-15475657792290.9819128808191682--
+
+------sinikael-?=_1-15475657792290.9819128808191682--


### PR DESCRIPTION
Some body parts can be 0 length and the part splitter code didn’t handle that.  We ran into this while parsing outlook meeting requests that were saved as EML files.

I think this is the last issue we've run into for now.  Thanks for the prompt responses!  If you accept this we'd appreciate a pull and re-release.  Thanks!