### PR TITLE
Change minimal iOS deployment target to 9.0

### DIFF
--- a/MimeParser.podspec
+++ b/MimeParser.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = "miximka"
 
-  s.ios.deployment_target = "10.3"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.12"
 
   s.source       = { :git => "https://github.com/miximka/MimeParser.git", :tag => "#{s.version}" }


### PR DESCRIPTION
This PR changes the minimal iOS deployment target from `10.3` to `9.0`, which allows me to use `MimeParser` for testing of my library [React Native Blob Courier](https://github.com/edeckers/react-native-blob-courier).