### PR TITLE
Support dynamic library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,22 +4,26 @@
 import PackageDescription
 
 let package = Package(
-    name: "MimeParser",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "MimeParser",
-            targets: ["MimeParser"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target( name: "MimeParser", dependencies: []),
-        .testTarget(name: "MimeParserTests", dependencies: ["MimeParser"], resources: [.process("Resources")])
-
-    ]
+  name: "MimeParser",
+  products: [
+    // Products define the executables and libraries produced by a package, and make them visible to other packages.
+    .library(
+      name: "MimeParser",
+      targets: ["MimeParser"]),
+    .library(
+      name: "MimeParserDynamic",
+      type: .dynamic,
+      targets: ["MimeParser"]),
+  ],
+  dependencies: [
+    // Dependencies declare other packages that this package depends on.
+    // .package(url: /* package url */, from: "1.0.0"),
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+    .target( name: "MimeParser", dependencies: []),
+    .testTarget(name: "MimeParserTests", dependencies: ["MimeParser"], resources: [.process("Resources")])
+    
+  ]
 )


### PR DESCRIPTION
Add a new dynamic target to the products list. This is useful for apps with multiple extensions, where each extension would need to link with MimeParser separately. The produced dynamic library can then be bundled once with the main target while other extensions load the shared 'framework'.

This also helps in situations where a conventional framework (in addition to the app's main target) used by an app may itself require linking with MimeParser. Xcode will link MimeParser statically to both the framework and the main app and will produce several warnings at runtime about duplicate symbols.

